### PR TITLE
Start bundle documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,43 @@
-# FeatureBundle for Symfony2
+# Feature Bundle for Symfony
 
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/adespresso/FeatureBundle/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/adespresso/FeatureBundle/?branch=master)
 [![Code Coverage](https://scrutinizer-ci.com/g/adespresso/FeatureBundle/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/adespresso/FeatureBundle/?branch=master)
 [![Build Status](https://scrutinizer-ci.com/g/adespresso/FeatureBundle/badges/build.png?b=master)](https://scrutinizer-ci.com/g/adespresso/FeatureBundle/build-status/master)
 
 This bundle manage release of new features to specific subsets of users.
+
+API: [adespresso.github.io/FeatureBundle](https://adespresso.github.io/FeatureBundle/)
+
+## Install
+
+Via Composer
+
+```console
+$ composer require adespresso/feature-bundle
+```
+
+## Documentation
+
+The source of the documentation is stored in the `Resources/doc/` folder in this bundle:
+
+[Documentation](Resources/doc/index.rst)
+
+## Change log
+
+Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
+
+## Testing
+
+```console
+$ vendor/bin/php-cs-fixer fix
+$ vendor/bin/phpunit
+```
+
+## Contributing
+
+Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+
+## License
+
+This bundle is under the MIT license.
+

--- a/Resources/doc/commands.rst
+++ b/Resources/doc/commands.rst
@@ -1,0 +1,16 @@
+Commands
+========
+
+The features built with this bundle are managed using some commands.
+
+The provided commands are:
+
+.. code-block:: bash
+
+    $ console features:create [--enabled] [--role ROLE] <parent> <name>
+    $ console features:disable <parent> <name>
+    $ console features:enable [--role ROLE] <parent> <name>
+    $ console features:load [--dry-run] <bundle>
+
+By executing the ``features:load`` command, used features are loaded and stored
+directly from the bundle *.twig files inside the ``Resources/views`` directory.

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,0 +1,53 @@
+Installation
+============
+
+Step 1: Download the Bundle
+---------------------------
+
+Open a command console, enter your project directory and execute the
+following command to download the latest stable version of this bundle:
+
+.. code-block:: bash
+
+    $ composer require adespresso/feature-bundle
+
+This command requires you to have Composer installed globally, as explained
+in the `installation chapter`_ of the Composer documentation.
+
+Step 2: Enable the Bundle
+-------------------------
+
+Then, enable the bundle by adding it to the list of registered bundles
+in the ``app/AppKernel.php`` file of your project:
+
+.. code-block:: php
+
+    <?php
+    // app/AppKernel.php
+
+    // ...
+    class AppKernel extends Kernel
+    {
+        public function registerBundles()
+        {
+            $bundles = array(
+                // ...
+
+                new Ae\FeatureBundle\AeFeatureBundle(),
+            );
+
+            // ...
+        }
+
+        // ...
+    }
+
+Documentation
+-------------
+
+-  `Usage`_
+-  `Commands`_
+
+.. _Usage: https://github.com/adespresso/FeatureBundle/tree/master/Resources/doc/usage.rst
+.. _Commands: https://github.com/adespresso/FeatureBundle/tree/master/Resources/doc/commands.rst
+.. _`installation chapter`: https://getcomposer.org/doc/00-intro.md

--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -1,0 +1,22 @@
+Usage
+=====
+
+You can use this bundle from your Twig templates:
+
+.. code-block:: twig
+
+    {% feature "feature" from "group" %}
+        feature enabled
+    {% else %}
+        feature disabled {# this will be the output #}
+    {% endfeature %}
+
+or from the service directly:
+
+.. code-block:: php
+
+    $featureService = $this->container->get('ae_feature.feature');
+
+    if (!$featureService->isGranted('feature', 'group')) {
+        throw new Exception();
+    }


### PR DESCRIPTION
Closes https://github.com/adespresso/FeatureBundle/issues/7
- [x] Readme
- [x] Index
- [x] Usage
- [x] ~Sonata Integration~ (to be done in https://github.com/adespresso/FeatureBundle/pull/24)
