### PR TITLE
Use the Fully Qualified Class Name instead of the extension name

### DIFF
--- a/Tests/Twig/Node/FeatureNodeTest.php
+++ b/Tests/Twig/Node/FeatureNodeTest.php
@@ -2,7 +2,9 @@
 
 namespace Ae\FeatureBundle\Tests\Twig\Node;
 
+use Ae\FeatureBundle\Twig\Extension\FeatureExtension;
 use Ae\FeatureBundle\Twig\Node\FeatureNode;
+use Twig_Environment;
 use Twig_Node;
 use Twig_Node_Expression_Name;
 use Twig_Node_Print;
@@ -38,18 +40,6 @@ class FeatureNodeTest extends Twig_Test_NodeTestCase
         $this->assertFalse($node->hasNode('else'));
     }
 
-    /**
-     * @dataProvider getTests
-     */
-    public function testCompile(
-        $node,
-        $source,
-        $environment = null,
-        $isPattern = null
-    ) {
-        parent::testCompile($node, $source, $environment, $isPattern);
-    }
-
     public function getTests()
     {
         $tests = [];
@@ -60,10 +50,14 @@ class FeatureNodeTest extends Twig_Test_NodeTestCase
             new Twig_Node_Print(new Twig_Node_Expression_Name('foo', 1), 1),
         ], [], 1);
 
+        $extension = Twig_Environment::VERSION_ID >= 12600
+            ? FeatureExtension::class
+            : 'feature';
+
         $node = new FeatureNode($name, $parent, $body, null, 1);
         $tests[] = [$node, <<<EOF
 // line 1
-if (\$this->env->getExtension('feature')->isGranted("$name", "$parent")) {
+if (\$this->env->getExtension('{$extension}')->isGranted("$name", "$parent")) {
     echo {$this->getVariableGetter('foo')};
 }
 EOF
@@ -75,7 +69,7 @@ EOF
         $node = new FeatureNode($name, $parent, $body, $else, 1);
         $tests[] = [$node, <<<EOF
 // line 1
-if (\$this->env->getExtension('feature')->isGranted("$name", "$parent")) {
+if (\$this->env->getExtension('{$extension}')->isGranted("$name", "$parent")) {
     echo {$this->getVariableGetter('foo')};
 } else {
     echo {$this->getVariableGetter('bar')};

--- a/Twig/Node/FeatureNode.php
+++ b/Twig/Node/FeatureNode.php
@@ -2,6 +2,8 @@
 
 namespace Ae\FeatureBundle\Twig\Node;
 
+use Ae\FeatureBundle\Twig\Extension\FeatureExtension;
+use Twig_Environment;
 use Twig_Node;
 use Twig_Node_Expression_Array;
 use Twig_Node_Expression_Constant;
@@ -27,7 +29,12 @@ class FeatureNode extends Twig_Node_If
     protected function createExpression($name, $parent, $lineno)
     {
         return new Twig_Node_Expression_MethodCall(
-            new Twig_Node_Expression_ExtensionReference('feature', $lineno),
+            new Twig_Node_Expression_ExtensionReference(
+                Twig_Environment::VERSION_ID >= 12600
+                    ? FeatureExtension::class
+                    : 'feature',
+                $lineno
+            ),
             'isGranted',
             new Twig_Node_Expression_Array(
                 [


### PR DESCRIPTION
Removed Twig deprecation:
> Referencing the "feature" extension by its name (defined by getName()) is deprecated since 1.26 and will be removed in Twig 2.0.
> Use the Fully Qualified Extension Class Name instead: 2x